### PR TITLE
修改为正确的vue.js引用文件

### DIFF
--- a/build/webpack.base.conf.js
+++ b/build/webpack.base.conf.js
@@ -38,7 +38,7 @@ module.exports = {
     extensions: ['', '.js', '.vue','.css'],
     fallback: [path.join(__dirname, '../node_modules')],
     alias: {
-      'vue$': 'vue/dist/vue',
+      'vue$': 'vue/dist/vue.common',
       'src': path.resolve(__dirname, '../src'),
       'assets': path.resolve(__dirname, '../src/assets'),
       'components': path.resolve(__dirname, '../src/components'),


### PR DESCRIPTION
vue.js是用于script标签引用的版本。而vue.common.js才是用于webpack进行打包的版本。这样可以解决先前即使是npm run build的production版本，依然会在控制台显示开发版本警告的问题。